### PR TITLE
fix for using 2 syringes

### DIFF
--- a/en.lua
+++ b/en.lua
@@ -51,6 +51,8 @@ Locales['en'] = {
     notenough = "You do not have $",
     doctoractive = "A Doctor is available, /alert instead",
     you_do_not_have_job = "You are missing the job needed",
-    cooldown = "Please wait "
+    cooldown = "Please wait ",
+    Youused ="You used",
+
 
 }

--- a/server/server.lua
+++ b/server/server.lua
@@ -136,6 +136,7 @@ AddEventHandler('legacy_medic:healplayer', function(closestPlayer)
     local _source = source
     local count = VORPInv.getItemCount(_source, Config.Bandage)
     if count > 0 then
+        VORPInv.subItem(_source, Config.Bandage, 1)
         TriggerClientEvent('vorp:heal', closestPlayer)
     else
         VorpCore.NotifyRightTip(_source, _U('Missing') .. Config.Bandage, 4000)
@@ -148,7 +149,6 @@ VORPInv.RegisterUsableItem(Config.Revive, function(data)
     local job = user.job
     if CheckTable(MedicJobs, job) then
         TriggerClientEvent('legacy_medic:getclosestplayerrevive', _source)
-        VORPInv.subItem(_source, Config.Revive, 1)
         VorpCore.NotifyRightTip(_source, "You used " .. Config.Revive, 4000)
     else
         VorpCore.NotifyRightTip(_source, "dont have the job", 4000)
@@ -158,7 +158,6 @@ VORPInv.RegisterUsableItem(Config.Revive, function(data)
 end)
 
 VORPInv.RegisterUsableItem(Config.Bandage, function(data)
-    VORPInv.subItem(data.source, Config.Bandage, 1)
     TriggerClientEvent('legacy_medic:getclosestplayerbandage', data.source)
     VorpCore.NotifyRightTip(data.source, "You used " .. Config.Bandage, 4000)
 end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -149,9 +149,9 @@ VORPInv.RegisterUsableItem(Config.Revive, function(data)
     local job = user.job
     if CheckTable(MedicJobs, job) then
         TriggerClientEvent('legacy_medic:getclosestplayerrevive', _source)
-        VorpCore.NotifyRightTip(_source, "You used " .. Config.Revive, 4000)
+    VorpCore.NotifyRightTip(data.source,_U('Youused').. Config.Revive, 4000)
     else
-        VorpCore.NotifyRightTip(_source, "dont have the job", 4000)
+        VorpCore.NotifyRightTip(_source,_U('youdonothavejob'), 4000)
 
     end
 
@@ -159,7 +159,7 @@ end)
 
 VORPInv.RegisterUsableItem(Config.Bandage, function(data)
     TriggerClientEvent('legacy_medic:getclosestplayerbandage', data.source)
-    VorpCore.NotifyRightTip(data.source, "You used " .. Config.Bandage, 4000)
+    VorpCore.NotifyRightTip(data.source,_U('Youused').. Config.Bandage, 4000)
 end)
 
 function CheckTable(table, element)

--- a/server/server.lua
+++ b/server/server.lua
@@ -151,7 +151,7 @@ VORPInv.RegisterUsableItem(Config.Revive, function(data)
         TriggerClientEvent('legacy_medic:getclosestplayerrevive', _source)
     VorpCore.NotifyRightTip(data.source,_U('Youused').. Config.Revive, 4000)
     else
-        VorpCore.NotifyRightTip(_source,_U('youdonothavejob'), 4000)
+        VorpCore.NotifyRightTip(_source,_U('you_do_not_have_job'), 4000)
 
     end
 


### PR DESCRIPTION
fix for using 2 syringes

it was using 2 for me
moved the removal of the item only after it checks for a player not in using the item
it was taking the items on use and after check
for revive not heal

